### PR TITLE
Define STRICT_R_HEADERS, include float.h

### DIFF
--- a/src/ER.cpp
+++ b/src/ER.cpp
@@ -10,8 +10,10 @@
  * // using namespace std;
  */
 
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
+#include <float.h>
 #include <math.h>
 
 

--- a/src/eig_RXmD.cpp
+++ b/src/eig_RXmD.cpp
@@ -1,6 +1,7 @@
 
 #ifndef _EIGS_SYM_RXmD_CC
 #define _EIGS_SYM_RXmD_CC
+#define STRICT_R_HEADERS
 #include <RcppEigen.h>
 #include <Rcpp.h>
 #include <SymEigs.h>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,6 +2,7 @@
 #ifndef _UTILS_CC_
 #define _UTILS_CC_
 
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 
 using namespace Rcpp;


### PR DESCRIPTION
Dear Somak, dear fad team,

Your CRAN package fad uses Rcpp, and is affected if we add the definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at
  https://github.com/RcppCore/Rcpp/issues/1158
and the links therein for more context on this.

Here, I prefixed three #include <Rcpp.h> with STRICT_R_HEADERS. One additional change that is needed is the #include of <float.h> (or cfloat if you prefer C style, that is equivalent) to define DBL_EPSILON, DBL_MIN, ...

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
 https://github.com/RcppCore/Rcpp/issues/1158
to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.